### PR TITLE
Add Docker setup for React Native

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+npm-debug.log
+android/app/build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM node:18-bullseye
+
+# Install Java and other tools needed for Android builds
+RUN apt-get update && apt-get install -y \
+    openjdk-17-jdk \
+    wget unzip git \
+ && rm -rf /var/lib/apt/lists/*
+
+# Android SDK installation
+ENV ANDROID_HOME=/opt/android-sdk
+ENV PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools
+
+RUN mkdir -p $ANDROID_HOME/cmdline-tools && \
+    cd $ANDROID_HOME/cmdline-tools && \
+    wget -q https://dl.google.com/android/repository/commandlinetools-linux-9477386_latest.zip -O tools.zip && \
+    unzip tools.zip && \
+    mv cmdline-tools latest && \
+    rm tools.zip && \
+    yes | sdkmanager --licenses && \
+    sdkmanager "platform-tools" "platforms;android-34" "build-tools;34.0.0"
+
+# React Native CLI
+RUN npm install -g react-native-cli
+
+WORKDIR /app
+
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
 # phone-blocking
+
+This repository includes a Docker Compose configuration for running a React Native development environment.
+
+## Prerequisites
+
+- Docker and Docker Compose installed on your machine.
+
+## Usage
+
+1. Build the Docker image:
+   ```
+   docker compose build
+   ```
+2. Start a development container (Metro bundler will expose port `8081`):
+   ```
+   docker compose run --service-ports app
+   ```
+   The project directory is mounted at `/app` inside the container.
+3. Inside the container you can create or run your React Native project, for example:
+   ```
+   npx react-native init MyApp
+   cd MyApp
+   npx react-native start
+   ```
+
+## Files
+
+- `Dockerfile` – sets up Node.js, Java, and Android SDK for React Native.
+- `docker-compose.yml` – configuration for launching the development container.
+- `.dockerignore` – files and folders excluded from the image build context.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.8"
+
+services:
+  app:
+    build: .
+    volumes:
+      - .:/app
+    ports:
+      - "8081:8081"
+    environment:
+      - ANDROID_HOME=/opt/android-sdk
+    tty: true
+    stdin_open: true


### PR DESCRIPTION
## Summary
- set up Dockerfile to build a React Native environment
- configure docker-compose for development
- ignore build artifacts in `.dockerignore`
- document setup in README

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687af7521efc832781161fd5e0cf1b1b