### PR TITLE
Implement blocked number store with AsyncStorage

### DIFF
--- a/PhoneBlockingApp/App.tsx
+++ b/PhoneBlockingApp/App.tsx
@@ -5,17 +5,20 @@
  * @format
  */
 
-import { NewAppScreen } from '@react-native/new-app-screen';
 import { StatusBar, StyleSheet, useColorScheme, View } from 'react-native';
+import BlockedNumbersScreen from './src/BlockedNumbersScreen';
+import {BlockedNumbersProvider} from './src/store/BlockedNumbersContext';
 
 function App() {
   const isDarkMode = useColorScheme() === 'dark';
 
   return (
-    <View style={styles.container}>
-      <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
-      <NewAppScreen templateFileName="App.tsx" />
-    </View>
+    <BlockedNumbersProvider>
+      <View style={styles.container}>
+        <StatusBar barStyle={isDarkMode ? 'light-content' : 'dark-content'} />
+        <BlockedNumbersScreen />
+      </View>
+    </BlockedNumbersProvider>
   );
 }
 

--- a/PhoneBlockingApp/jest.config.js
+++ b/PhoneBlockingApp/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   preset: 'react-native',
+  setupFiles: ['<rootDir>/jest.setup.js'],
 };

--- a/PhoneBlockingApp/jest.setup.js
+++ b/PhoneBlockingApp/jest.setup.js
@@ -1,0 +1,2 @@
+import mockAsyncStorage from '@react-native-async-storage/async-storage/jest/async-storage-mock';
+jest.mock('@react-native-async-storage/async-storage', () => mockAsyncStorage);

--- a/PhoneBlockingApp/package-lock.json
+++ b/PhoneBlockingApp/package-lock.json
@@ -8,6 +8,7 @@
       "name": "PhoneBlockingApp",
       "version": "0.0.1",
       "dependencies": {
+        "@react-native-async-storage/async-storage": "^1.23.1",
         "@react-native/new-app-screen": "0.80.1",
         "react": "19.1.0",
         "react-native": "0.80.1"
@@ -2716,6 +2717,18 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@react-native-async-storage/async-storage": {
+      "version": "1.24.0",
+      "resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+      "integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+      "license": "MIT",
+      "dependencies": {
+        "merge-options": "^3.0.4"
+      },
+      "peerDependencies": {
+        "react-native": "^0.0.0-0 || >=0.60 <1.0"
       }
     },
     "node_modules/@react-native-community/cli": {
@@ -7395,6 +7408,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -9086,6 +9108,18 @@
       "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.2.1.tgz",
       "integrity": "sha512-zYiwtZUcYyXKo/np96AGZAckk+FWWsUdJ3cHGGmld7+AhvcWmQyGCYUh1hc4Q/pkOhb65dQR/pqCyK0cOaHz4Q==",
       "license": "MIT"
+    },
+    "node_modules/merge-options": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-3.0.4.tgz",
+      "integrity": "sha512-2Sug1+knBjkaMsMgf1ctR1Ujx+Ayku4EdJN4Z+C2+JzoeF7A3OZ9KM2GY0CpQS51NR61LTurMJrRKPhSs3ZRTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",

--- a/PhoneBlockingApp/package.json
+++ b/PhoneBlockingApp/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "19.1.0",
     "react-native": "0.80.1",
-    "@react-native/new-app-screen": "0.80.1"
+    "@react-native/new-app-screen": "0.80.1",
+    "@react-native-async-storage/async-storage": "^1.23.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/PhoneBlockingApp/src/BlockedNumbersScreen.tsx
+++ b/PhoneBlockingApp/src/BlockedNumbersScreen.tsx
@@ -1,0 +1,83 @@
+import React, {useState} from 'react';
+import {
+  SafeAreaView,
+  StyleSheet,
+  View,
+  Text,
+  TextInput,
+  Button,
+  FlatList,
+} from 'react-native';
+import {useBlockedNumbers} from './store/BlockedNumbersContext';
+
+export default function BlockedNumbersScreen() {
+  const {numbers, addNumber, removeNumber} = useBlockedNumbers();
+  const [input, setInput] = useState('');
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.inputRow}>
+        <TextInput
+          style={styles.input}
+          placeholder="Enter number"
+          keyboardType="phone-pad"
+          value={input}
+          onChangeText={setInput}
+        />
+        <Button
+          title="Add"
+          onPress={() => {
+            if (input.trim()) {
+              addNumber(input.trim());
+              setInput('');
+            }
+          }}
+        />
+      </View>
+      <FlatList
+        data={numbers}
+        keyExtractor={item => item}
+        renderItem={({item}) => (
+          <View style={styles.itemRow}>
+            <Text style={styles.itemText}>{item}</Text>
+            <Button title="Remove" onPress={() => removeNumber(item)} />
+          </View>
+        )}
+        ListEmptyComponent={<Text style={styles.empty}>No blocked numbers</Text>}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  inputRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  input: {
+    flex: 1,
+    borderColor: '#ccc',
+    borderWidth: 1,
+    marginRight: 8,
+    paddingHorizontal: 8,
+    height: 40,
+    borderRadius: 4,
+  },
+  itemRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 8,
+  },
+  itemText: {
+    flex: 1,
+  },
+  empty: {
+    textAlign: 'center',
+    color: '#666',
+  },
+});

--- a/PhoneBlockingApp/src/store/BlockedNumbersContext.tsx
+++ b/PhoneBlockingApp/src/store/BlockedNumbersContext.tsx
@@ -1,0 +1,81 @@
+import React, {createContext, useContext, useEffect, useReducer} from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+interface State {
+  numbers: string[];
+}
+
+type Action =
+  | {type: 'load'; numbers: string[]}
+  | {type: 'add'; number: string}
+  | {type: 'remove'; number: string};
+
+const STORAGE_KEY = '@blocked_numbers';
+
+const BlockedNumbersStateContext = createContext<State | undefined>(undefined);
+const BlockedNumbersDispatchContext = createContext<{
+  addNumber: (n: string) => void;
+  removeNumber: (n: string) => void;
+} | undefined>(undefined);
+
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'load':
+      return {numbers: action.numbers};
+    case 'add':
+      if (state.numbers.includes(action.number)) {
+        return state;
+      }
+      return {numbers: [...state.numbers, action.number]};
+    case 'remove':
+      return {numbers: state.numbers.filter(n => n !== action.number)};
+    default:
+      return state;
+  }
+}
+
+export const BlockedNumbersProvider: React.FC<{children: React.ReactNode}> = ({
+  children,
+}) => {
+  const [state, dispatch] = useReducer(reducer, {numbers: []});
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const raw = await AsyncStorage.getItem(STORAGE_KEY);
+        if (raw) {
+          const nums = JSON.parse(raw) as string[];
+          dispatch({type: 'load', numbers: nums});
+        }
+      } catch (e) {
+        console.warn('Failed to load numbers', e);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(state.numbers)).catch(e =>
+      console.warn('Failed to save numbers', e),
+    );
+  }, [state.numbers]);
+
+  const addNumber = (number: string) => dispatch({type: 'add', number});
+  const removeNumber = (number: string) => dispatch({type: 'remove', number});
+
+  return (
+    <BlockedNumbersDispatchContext.Provider value={{addNumber, removeNumber}}>
+      <BlockedNumbersStateContext.Provider value={state}>
+        {children}
+      </BlockedNumbersStateContext.Provider>
+    </BlockedNumbersDispatchContext.Provider>
+  );
+};
+
+export function useBlockedNumbers() {
+  const state = useContext(BlockedNumbersStateContext);
+  const dispatch = useContext(BlockedNumbersDispatchContext);
+  if (!state || !dispatch) {
+    throw new Error('useBlockedNumbers must be used within BlockedNumbersProvider');
+  }
+  return {numbers: state.numbers, ...dispatch};
+}


### PR DESCRIPTION
## Summary
- add AsyncStorage dependency
- implement context-based store for blocked numbers
- provide BlockedNumbersScreen UI
- wrap app with store provider
- mock AsyncStorage in Jest and update configuration

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883e12ed81c8327b768ef6fd7a0a2c7