### PR TITLE
Add call screening blacklist

### DIFF
--- a/PhoneBlockingApp/README.md
+++ b/PhoneBlockingApp/README.md
@@ -95,3 +95,7 @@ To learn more about React Native, take a look at the following resources:
 - [Learn the Basics](https://reactnative.dev/docs/getting-started) - a **guided tour** of the React Native **basics**.
 - [Blog](https://reactnative.dev/blog) - read the latest official React Native **Blog** posts.
 - [`@facebook/react-native`](https://github.com/facebook/react-native) - the Open Source; GitHub **repository** for React Native.
+
+## Call Blocking
+
+This app includes an Android call screening service. To enable blocking of numbers added in the app, open the system **Call Screening** settings and select *PhoneBlockingApp* as the default provider.

--- a/PhoneBlockingApp/android/app/src/main/AndroidManifest.xml
+++ b/PhoneBlockingApp/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
+    <uses-permission android:name="android.permission.CALL_SCREENING" />
+
     <uses-permission android:name="android.permission.INTERNET" />
 
     <application
@@ -22,5 +24,14 @@
             <category android:name="android.intent.category.LAUNCHER" />
         </intent-filter>
       </activity>
+
+      <service
+        android:name=".CallBlockerService"
+        android:permission="android.permission.BIND_SCREENING_SERVICE"
+        android:exported="true">
+        <intent-filter>
+          <action android:name="android.telecom.CallScreeningService" />
+        </intent-filter>
+      </service>
     </application>
 </manifest>

--- a/PhoneBlockingApp/android/app/src/main/java/com/phoneblockingapp/CallBlockerService.kt
+++ b/PhoneBlockingApp/android/app/src/main/java/com/phoneblockingapp/CallBlockerService.kt
@@ -1,0 +1,35 @@
+package com.phoneblockingapp
+
+import android.content.Context
+import android.service.calls.CallScreeningService
+import android.service.calls.CallScreeningService.CallResponse
+import android.util.Log
+import org.json.JSONArray
+
+class CallBlockerService : CallScreeningService() {
+    override fun onScreenCall(details: Call.Details) {
+        val prefs = applicationContext.getSharedPreferences("RNAsyncStorage", Context.MODE_PRIVATE)
+        val json = prefs.getString("@blocked_numbers", "[]")
+        val numbers = mutableSetOf<String>()
+        try {
+            val arr = JSONArray(json)
+            for (i in 0 until arr.length()) {
+                numbers.add(arr.getString(i))
+            }
+        } catch (e: Exception) {
+            Log.w("CallBlockerService", "Failed to parse blocked numbers", e)
+        }
+
+        val incoming = details.handle?.schemeSpecificPart
+        if (incoming != null && numbers.contains(incoming)) {
+            val response = CallResponse.Builder()
+                .setDisallowCall(true)
+                .setRejectCall(true)
+                .setSkipNotification(true)
+                .build()
+            respondToCall(details, response)
+        } else {
+            respondToCall(details, CallResponse.Builder().build())
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `CallBlockerService` on Android to reject incoming calls from numbers stored in AsyncStorage
- register the service in the Android manifest
- document enabling the service in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68896a8259b48327a248e99bfbbb663e